### PR TITLE
add refresh_after parameter to add_image method 

### DIFF
--- a/image_match/elasticsearch_driver.py
+++ b/image_match/elasticsearch_driver.py
@@ -88,9 +88,9 @@ class SignatureES(SignatureDatabaseBase):
 
         return formatted_res
 
-    def insert_single_record(self, rec):
+    def insert_single_record(self, rec, refresh_after=False):
         rec['timestamp'] = datetime.now()
-        self.es.index(index=self.index, doc_type=self.doc_type, body=rec)
+        self.es.index(index=self.index, doc_type=self.doc_type, body=rec, refresh=refresh_after)
 
     def delete_duplicates(self, path):
         """Delete all but one entries in elasticsearch whose `path` value is equivalent to that of path.

--- a/image_match/signature_database_base.py
+++ b/image_match/signature_database_base.py
@@ -181,7 +181,7 @@ class SignatureDatabaseBase(object):
 
         self.gis = ImageSignature(n=n_grid, crop_percentiles=crop_percentile, *signature_args, **signature_kwargs)
 
-    def add_image(self, path, img=None, bytestream=False, metadata=None):
+    def add_image(self, path, img=None, bytestream=False, metadata=None, refresh_after=False):
         """Add a single image to the database
 
         Args:
@@ -200,7 +200,7 @@ class SignatureDatabaseBase(object):
 
         """
         rec = make_record(path, self.gis, self.k, self.N, img=img, bytestream=bytestream, metadata=metadata)
-        self.insert_single_record(rec)
+        self.insert_single_record(rec, refresh_after=refresh_after)
 
     def search_image(self, path, all_orientations=False, bytestream=False):
         """Search for matches

--- a/tests/test_elasticsearch_driver.py
+++ b/tests/test_elasticsearch_driver.py
@@ -198,6 +198,6 @@ def test_duplicate_removal(ses):
 
 
 def test_index_refresh(ses):
-    ses.add_image('test1.jpg')
-    r = ses.search_image('test1.jpg', refresh_after=True)
+    ses.add_image('test1.jpg', refresh_after=True)
+    r = ses.search_image('test1.jpg')
     assert len(r) == 1

--- a/tests/test_elasticsearch_driver.py
+++ b/tests/test_elasticsearch_driver.py
@@ -195,3 +195,9 @@ def test_duplicate_removal(ses):
     sleep(1)
     r = ses.search_image('test1.jpg')
     assert len(r) == 1
+
+
+def test_index_refresh(ses):
+    ses.add_image('test1.jpg')
+    r = ses.search_image('test1.jpg', refresh_after=True)
+    assert len(r) == 1


### PR DESCRIPTION
This PR allows us to refresh elasticsearch after an image has been add by passing `refresh_after=True` as a parameter in the `add_image` method.
