### PR TITLE
Make cairo optional

### DIFF
--- a/image_match/goldberg.py
+++ b/image_match/goldberg.py
@@ -8,6 +8,11 @@ except ImportError:
     pass
 from io import BytesIO
 import numpy as np
+import xml.etree
+
+
+class CorruptImageError(RuntimeError):
+    pass
 
 
 class ImageSignature(object):
@@ -222,7 +227,10 @@ class ImageSignature(object):
                 img = Image.open(BytesIO(image_or_path))
             except IOError:
                 # could be an svg, attempt to convert
-                img = Image.open(BytesIO(svg2png(image_or_path)))
+                try:
+                    img = Image.open(BytesIO(svg2png(image_or_path)))
+                except (NameError, xml.etree.ElementTree.ParseError):
+                    raise CorruptImageError()
             img = img.convert('RGB')
             return rgb2gray(np.asarray(img, dtype=np.uint8))
         elif type(image_or_path) is str:

--- a/image_match/goldberg.py
+++ b/image_match/goldberg.py
@@ -2,7 +2,10 @@ from skimage.color import rgb2gray
 from skimage.io import imread
 from PIL import Image
 from PIL.MpoImagePlugin import MpoImageFile
-from cairosvg import svg2png
+try:
+    from cairosvg import svg2png
+except ImportError:
+    pass
 from io import BytesIO
 import numpy as np
 
@@ -218,7 +221,7 @@ class ImageSignature(object):
             try:
                 img = Image.open(BytesIO(image_or_path))
             except IOError:
-                #  could be an svg, attempt to convert
+                # could be an svg, attempt to convert
                 img = Image.open(BytesIO(svg2png(image_or_path)))
             img = img.convert('RGB')
             return rgb2gray(np.asarray(img, dtype=np.uint8))
@@ -229,7 +232,7 @@ class ImageSignature(object):
                 img = Image.open(image_or_path)
                 arr = np.array(img.convert('RGB'))
             except IOError:
-                #  try again due to PIL weirdness
+                # try again due to PIL weirdness
                 return imread(image_or_path, as_grey=True)
             if handle_mpo:
                 # take the first images from the MPO

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ setup(
     ],
     install_requires=[
         'scikit-image>=0.12,<0.13',
-        'cairosvg>1,<2',
         'elasticsearch>=2.3,<2.4',
     ],
     tests_require=tests_require,
@@ -97,5 +96,6 @@ setup(
         'test': tests_require,
         'dev':  dev_require + tests_require + docs_require,
         'docs':  docs_require,
+        'extra': ['cairosvg>1,<2'],
     },
 )

--- a/tests/test_goldberg.py
+++ b/tests/test_goldberg.py
@@ -2,7 +2,7 @@ import pytest
 from numpy import ndarray, array_equal
 import urllib.request
 
-from image_match.goldberg import ImageSignature
+from image_match.goldberg import ImageSignature, CorruptImageError
 
 test_img_url = 'https://camo.githubusercontent.com/810bdde0a88bc3f8ce70c5d85d8537c37f707abe/68747470733a2f2f75706c6f61642e77696b696d656469612e6f72672f77696b6970656469612f636f6d6d6f6e732f7468756d622f652f65632f4d6f6e615f4c6973612c5f62795f4c656f6e6172646f5f64615f56696e63692c5f66726f6d5f4332524d465f7265746f75636865642e6a70672f36383770782d4d6f6e615f4c6973612c5f62795f4c656f6e6172646f5f64615f56696e63692c5f66726f6d5f4332524d465f7265746f75636865642e6a7067'
 test_diff_img_url = 'https://camo.githubusercontent.com/826e23bc3eca041110a5af467671b012606aa406/68747470733a2f2f63322e737461746963666c69636b722e636f6d2f382f373135382f363831343434343939315f303864383264653537655f7a2e6a7067'
@@ -29,6 +29,12 @@ def test_load_from_stream():
         sig = gis.generate_signature(f.read(), bytestream=True)
         assert type(sig) is ndarray
         assert sig.shape == (648,)
+
+
+def test_load_from_corrupt_stream():
+    gis = ImageSignature()
+    with pytest.raises(CorruptImageError):
+        gis.generate_signature(b'corrupt', bytestream=True)
 
 
 def test_all_inputs_same_sig():


### PR DESCRIPTION
Also implements #60, because it's in the sample place, and `NameError` needs to be handled anyway