### PR TITLE
Ability to apply filter by metadata without affecting scoring 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ docs/_build/
 # PyBuilder
 target/
 image_match/web/static/tmp/
+
+*.jpg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,31 @@
 language: python
-python:
-  - 3.4
 
-services:
-  - elasticsearch
-  
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+
 before_install:
-  - curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.0/elasticsearch-2.3.0.deb && sudo dpkg -i --force-confnew elasticsearch-2.3.0.deb && sudo service elasticsearch restart
+  - sudo update-java-alternatives -s java-8-oracle
+  - export JAVA_HOME=/usr/lib/jvm/java-8-oracle/jre
+  - java -version
+
+python:
+  - 3.5
+
+env:
+  global:
+    - WAIT_FOR_ES=1
+    - ES_VERSION=5.2.2
 
 # From http://conda.pydata.org/docs/travis.html
+# https://github.com/elastic/elasticsearch-dsl-py/blob/master/.travis.yml
 install:
+  - mkdir /tmp/elasticsearch
+  - wget -O - https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
+  - /tmp/elasticsearch/bin/elasticsearch -d  
   - sudo apt-get update
+
   # We do this conditionally because it saves us some downloading if the
   # version is the same.
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
 
 services:
   - elasticsearch
+  
+before_install:
+  - curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.0/elasticsearch-2.3.0.deb && sudo dpkg -i --force-confnew elasticsearch-2.3.0.deb && sudo service elasticsearch restart
 
 # From http://conda.pydata.org/docs/travis.html
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:3.5
 
 RUN apt-get update && apt-get install -y libblas-dev liblapack-dev gfortran
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,43 @@
 version: '2'
 
 services:
+
   image-match:
-    build: .
+    build: 
+      context: .
+    image: ascribe/image-match
+    container_name: image-match
     volumes:
       - .:/usr/src/app/
-    links:
-      - elasticsearch
+    depends_on:
+     - "elasticsearch"
+
   elasticsearch:
-    image: elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.2.2
+    container_name: elasticsearch
+    environment:
+      - xpack.security.enabled=false
+      - xpack.monitoring.enabled=false
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "9200:9200"
+
   bdocs:
-    build: .
+    build: 
+      context: .
+    image: ascribe/image-match
+    container_name: bdocs
     volumes:
       - .:/usr/src/app/
     working_dir: /usr/src/app/docs
     command: make html
+    
   vdocs:
-    image: nginx
+    image: nginx:alpine
     ports:
       - '40080:80'
     volumes:

--- a/image_match/elasticsearch_driver.py
+++ b/image_match/elasticsearch_driver.py
@@ -62,7 +62,7 @@ class SignatureES(SignatureDatabaseBase):
         }
 
         if pre_filter is not None:
-            body['query']['filter'] = pre_filter
+            body['query']['bool']['filter'] = pre_filter
 
         res = self.es.search(index=self.index,
                               doc_type=self.doc_type,

--- a/image_match/elasticsearch_driver.py
+++ b/image_match/elasticsearch_driver.py
@@ -46,7 +46,7 @@ class SignatureES(SignatureDatabaseBase):
 
         super(SignatureES, self).__init__(*args, **kwargs)
 
-    def search_single_record(self, rec, filter=None):
+    def search_single_record(self, rec, pre_filter=None):
         path = rec.pop('path')
         signature = rec.pop('signature')
         if 'metadata' in rec:
@@ -61,8 +61,8 @@ class SignatureES(SignatureDatabaseBase):
             '_source': {'excludes': ['simple_word_*']}
         }
 
-        if filter is not None:
-            body['query']['filter'] = filter
+        if pre_filter is not None:
+            body['query']['filter'] = pre_filter
 
         res = self.es.search(index=self.index,
                               doc_type=self.doc_type,

--- a/image_match/mongodb_driver.py
+++ b/image_match/mongodb_driver.py
@@ -42,7 +42,7 @@ class SignatureMongo(SignatureDatabaseBase):
         super(SignatureMongo, self).__init__(*args, **kwargs)
 
     def search_single_record(self, rec, n_parallel_words=1, word_limit=None,
-                             process_timeout=None, maximum_matches=1000):
+                             process_timeout=None, maximum_matches=1000, filter=None):
         if n_parallel_words is None:
             n_parallel_words = cpu_count()
 

--- a/image_match/signature_database_base.py
+++ b/image_match/signature_database_base.py
@@ -13,7 +13,7 @@ class SignatureDatabaseBase(object):
 
     """
 
-    def search_single_record(self, rec, filter=None):
+    def search_single_record(self, rec, pre_filter=None):
         """Search for a matching image record.
 
         Must be implemented by derived class.
@@ -48,7 +48,7 @@ class SignatureDatabaseBase(object):
 
                  The number of simple words corresponds to the attribute N
 
-            filter (dict): a filter to be applied by the concrete implementation
+            pre_filter (dict): a filter to be applied by the concrete implementation
                    before applying the matching strategy
 
                 For example:
@@ -208,7 +208,7 @@ class SignatureDatabaseBase(object):
         rec = make_record(path, self.gis, self.k, self.N, img=img, bytestream=bytestream, metadata=metadata)
         self.insert_single_record(rec, refresh_after=refresh_after)
 
-    def search_image(self, path, all_orientations=False, bytestream=False, filter=None):
+    def search_image(self, path, all_orientations=False, bytestream=False, pre_filter=None):
         """Search for matches
 
         Args:
@@ -219,7 +219,7 @@ class SignatureDatabaseBase(object):
             bytestream (Optional[boolean]): will the image be passed as raw bytes?
                 That is, is the 'path_or_image' argument an in-memory image?
                 (default False)
-            filter (Optional[dict]): filter list before applying matching algorithm
+            pre_filter (Optional[dict]): filters list before applying the matching algorithm
                 (default None)
         Returns:
             a formatted list of dicts representing unique matches, sorted by dist
@@ -272,7 +272,7 @@ class SignatureDatabaseBase(object):
             # generate the signature
             transformed_record = make_record(transformed_img, self.gis, self.k, self.N)
 
-            l = self.search_single_record(transformed_record, filter=filter)
+            l = self.search_single_record(transformed_record, pre_filter=pre_filter)
             result.extend(l)
 
         ids = set()

--- a/image_match/signature_database_base.py
+++ b/image_match/signature_database_base.py
@@ -13,7 +13,7 @@ class SignatureDatabaseBase(object):
 
     """
 
-    def search_single_record(self, rec):
+    def search_single_record(self, rec, filter=None):
         """Search for a matching image record.
 
         Must be implemented by derived class.
@@ -47,6 +47,12 @@ class SignatureDatabaseBase(object):
                  }
 
                  The number of simple words corresponds to the attribute N
+
+            filter (dict): a filter to be applied by the concrete implementation
+                   before applying the matching strategy
+
+                For example:
+                    { "term": {  "metadata.category": "art" } }
 
         Returns:
             a formatted list of dicts representing matches.
@@ -202,7 +208,7 @@ class SignatureDatabaseBase(object):
         rec = make_record(path, self.gis, self.k, self.N, img=img, bytestream=bytestream, metadata=metadata)
         self.insert_single_record(rec, refresh_after=refresh_after)
 
-    def search_image(self, path, all_orientations=False, bytestream=False):
+    def search_image(self, path, all_orientations=False, bytestream=False, filter=None):
         """Search for matches
 
         Args:
@@ -213,7 +219,8 @@ class SignatureDatabaseBase(object):
             bytestream (Optional[boolean]): will the image be passed as raw bytes?
                 That is, is the 'path_or_image' argument an in-memory image?
                 (default False)
-
+            filter (Optional[dict]): filter list before applying matching algorithm
+                (default None)
         Returns:
             a formatted list of dicts representing unique matches, sorted by dist
 
@@ -265,7 +272,7 @@ class SignatureDatabaseBase(object):
             # generate the signature
             transformed_record = make_record(transformed_img, self.gis, self.k, self.N)
 
-            l = self.search_single_record(transformed_record)
+            l = self.search_single_record(transformed_record, filter)
             result.extend(l)
 
         ids = set()

--- a/image_match/signature_database_base.py
+++ b/image_match/signature_database_base.py
@@ -272,7 +272,7 @@ class SignatureDatabaseBase(object):
             # generate the signature
             transformed_record = make_record(transformed_img, self.gis, self.k, self.N)
 
-            l = self.search_single_record(transformed_record, filter)
+            l = self.search_single_record(transformed_record, filter=filter)
             result.extend(l)
 
         ids = set()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
+; python_functions = test_lookup_with_filter_by_metadata
 norecursedirs = .* *.egg *.egg-info env* devenv* docs

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(
     ],
     install_requires=[
         'scikit-image>=0.12,<0.13',
-        'elasticsearch>=2.3,<2.4',
+        'elasticsearch>=5.0.0,<6.0.0',
     ],
     tests_require=tests_require,
     extras_require={

--- a/tests/test_elasticsearch_driver.py
+++ b/tests/test_elasticsearch_driver.py
@@ -24,7 +24,10 @@ MAPPINGS = {
             "type": "object",
             "dynamic": True,
             "properties": { 
-                "tenant_id": { "type": "keyword" }
+                "tenant_id": { 
+                    "type": "string", 
+                    "index": "not_analyzed" 
+                }
             } 
         }
       }

--- a/tests/test_elasticsearch_driver.py
+++ b/tests/test_elasticsearch_driver.py
@@ -14,6 +14,25 @@ urllib.request.urlretrieve(test_img_url1, 'test1.jpg')
 urllib.request.urlretrieve(test_img_url2, 'test2.jpg')
 
 INDEX_NAME = 'test_environment_{}'.format(hashlib.md5(os.urandom(128)).hexdigest()[:12])
+DOC_TYPE = 'image'
+MAPPINGS = {
+  "mappings": {
+    DOC_TYPE: { 
+      "dynamic": True,
+      "properties": { 
+        "metadata": { 
+            "type": "object",
+            "dynamic": True,
+            "properties": { 
+                "tenant_id": { "type": "keyword" }
+            } 
+        }
+      }
+    }
+  }
+}
+
+
 @pytest.fixture(scope='module', autouse=True)
 def index_name():
     return INDEX_NAME
@@ -22,7 +41,7 @@ def index_name():
 def setup_index(request, index_name):
     es = Elasticsearch()
     try:
-        es.indices.create(index=index_name)
+        es.indices.create(index=index_name, body=MAPPINGS)
     except RequestError as e:
         if e.error == u'index_already_exists_exception':
             es.indices.delete(index_name)
@@ -52,7 +71,7 @@ def es():
 
 @pytest.fixture
 def ses(es, index_name):
-    return SignatureES(es=es, index=index_name)
+    return SignatureES(es=es, index=index_name, doc_type=DOC_TYPE)
 
 def test_elasticsearch_running(es):
     i = 0
@@ -155,6 +174,29 @@ def test_add_image_with_metadata(ses):
     assert 'dist' in r[0]
     assert 'id' in r[0]
 
+
+def test_lookup_with_filter_by_metadata(ses):
+    metadata = dict(
+            tenant_id='foo'
+    )
+    ses.add_image('test1.jpg', metadata=metadata, refresh_after=True)
+
+    metadata2 = dict(
+            tenant_id='bar-2'
+    )
+    ses.add_image('test2.jpg', metadata=metadata2, refresh_after=True)
+
+    r = ses.search_image('test1.jpg', pre_filter={"term": {"metadata.tenant_id": "foo"}})
+    assert len(r) == 1
+    assert r[0]['metadata'] == metadata
+
+    r = ses.search_image('test1.jpg', pre_filter={"term": {"metadata.tenant_id": "bar-2"}})
+    assert len(r) == 1
+    assert r[0]['metadata'] == metadata2
+
+    r = ses.search_image('test1.jpg', pre_filter={"term": {"metadata.tenant_id": "bar-3"}})
+    assert len(r) == 0
+    
 
 def test_all_orientations(ses):
     im = Image.open('test1.jpg')

--- a/tests/test_elasticsearch_driver.py
+++ b/tests/test_elasticsearch_driver.py
@@ -24,10 +24,7 @@ MAPPINGS = {
             "type": "object",
             "dynamic": True,
             "properties": { 
-                "tenant_id": { 
-                    "type": "string", 
-                    "index": "not_analyzed" 
-                }
+                "tenant_id": { "type": "keyword" }
             } 
         }
       }

--- a/tests/test_elasticsearch_driver_metadata_as_nested.py
+++ b/tests/test_elasticsearch_driver_metadata_as_nested.py
@@ -1,0 +1,134 @@
+import pytest
+import urllib.request
+import os
+import hashlib
+from elasticsearch import Elasticsearch, ConnectionError, RequestError, NotFoundError
+from time import sleep
+
+from image_match.elasticsearch_driver import SignatureES
+from PIL import Image
+
+test_img_url1 = 'https://camo.githubusercontent.com/810bdde0a88bc3f8ce70c5d85d8537c37f707abe/68747470733a2f2f75706c6f61642e77696b696d656469612e6f72672f77696b6970656469612f636f6d6d6f6e732f7468756d622f652f65632f4d6f6e615f4c6973612c5f62795f4c656f6e6172646f5f64615f56696e63692c5f66726f6d5f4332524d465f7265746f75636865642e6a70672f36383770782d4d6f6e615f4c6973612c5f62795f4c656f6e6172646f5f64615f56696e63692c5f66726f6d5f4332524d465f7265746f75636865642e6a7067'
+test_img_url2 = 'https://camo.githubusercontent.com/826e23bc3eca041110a5af467671b012606aa406/68747470733a2f2f63322e737461746963666c69636b722e636f6d2f382f373135382f363831343434343939315f303864383264653537655f7a2e6a7067'
+urllib.request.urlretrieve(test_img_url1, 'test1.jpg')
+urllib.request.urlretrieve(test_img_url2, 'test2.jpg')
+
+INDEX_NAME = 'test_environment_{}'.format(hashlib.md5(os.urandom(128)).hexdigest()[:12])
+DOC_TYPE = 'image'
+MAPPINGS = {
+  "mappings": {
+    DOC_TYPE: { 
+      "dynamic": True,
+      "properties": { 
+        "metadata": { 
+            "type": "nested",
+            "dynamic": True,
+            "properties": { 
+                "tenant_id": { "type": "keyword" },
+                "project_id": { "type": "keyword" }
+            } 
+        }
+      }
+    }
+  }
+}
+
+
+@pytest.fixture(scope='module', autouse=True)
+def index_name():
+    return INDEX_NAME
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_index(request, index_name):
+    es = Elasticsearch()
+    try:
+        es.indices.create(index=index_name, body=MAPPINGS)
+    except RequestError as e:
+        if e.error == u'index_already_exists_exception':
+            es.indices.delete(index_name)
+        else:
+            raise
+
+    def fin():
+        try:
+            es.indices.delete(index_name)
+        except NotFoundError:
+            pass
+
+    request.addfinalizer(fin)
+
+@pytest.fixture(scope='function', autouse=True)
+def cleanup_index(request, es, index_name):
+    def fin():
+        try:
+            es.indices.delete(index_name)
+        except NotFoundError:
+            pass
+    request.addfinalizer(fin)
+
+@pytest.fixture
+def es():
+    return Elasticsearch()
+
+@pytest.fixture
+def ses(es, index_name):
+    return SignatureES(es=es, index=index_name, doc_type=DOC_TYPE)
+
+def test_elasticsearch_running(es):
+    i = 0
+    while i < 5:
+        try:
+            es.ping()
+            assert True
+            return
+        except ConnectionError:
+            i += 1
+            sleep(2)
+
+    pytest.fail('Elasticsearch not running (failed to connect after {} tries)'
+                .format(str(i)))
+
+
+def test_lookup_with_filter_by_metadata(ses):
+
+    ses.add_image('test1.jpg', metadata=_metadata('foo', 'project-x'), refresh_after=True)
+    ses.add_image('test2.jpg', metadata=_metadata('foo', 'project-x'), refresh_after=True)
+    ses.add_image('test3.jpg', img='test1.jpg', metadata=_metadata('foo', 'project-y'), refresh_after=True)
+
+    ses.add_image('test2.jpg', metadata=_metadata('bar', 'project-x'), refresh_after=True)
+
+    r = ses.search_image('test1.jpg', pre_filter=_nested_filter('foo', 'project-x'))
+    assert len(r) == 2
+
+    r = ses.search_image('test1.jpg', pre_filter=_nested_filter('foo', 'project-z'))
+    assert len(r) == 0  
+
+    r = ses.search_image('test1.jpg', pre_filter=_nested_filter('bar', 'project-x'))
+    assert len(r) == 1
+
+    r = ses.search_image('test1.jpg', pre_filter=_nested_filter('bar-2', 'project-x'))
+    assert len(r) == 0
+    
+    r = ses.search_image('test1.jpg', pre_filter=_nested_filter('bar', 'project-z'))
+    assert len(r) == 0    
+    
+def _metadata(tenant_id, project_id):
+    return dict(
+            tenant_id=tenant_id,
+            project_id=project_id
+    )
+    
+def _nested_filter(tenant_id, project_id):
+    return {
+        "nested" : {
+            "path" : "metadata",
+            "query" : {
+                "bool" : {
+                    "must" : [
+                        {"term": {"metadata.tenant_id": tenant_id}},
+                        {"term": {"metadata.project_id": project_id}}
+                    ]
+                }
+             }            
+        }
+    }

--- a/tests/test_elasticsearch_driver_metadata_as_nested.py
+++ b/tests/test_elasticsearch_driver_metadata_as_nested.py
@@ -24,14 +24,8 @@ MAPPINGS = {
             "type": "nested",
             "dynamic": True,
             "properties": { 
-                "tenant_id": { 
-                    "type": "string", 
-                    "index": "not_analyzed" 
-                },
-                "project_id": { 
-                    "type": "string", 
-                    "index": "not_analyzed" 
-                }
+                "tenant_id": { "type": "keyword" },
+                "project_id": { "type": "keyword" }
             } 
         }
       }

--- a/tests/test_elasticsearch_driver_metadata_as_nested.py
+++ b/tests/test_elasticsearch_driver_metadata_as_nested.py
@@ -24,8 +24,14 @@ MAPPINGS = {
             "type": "nested",
             "dynamic": True,
             "properties": { 
-                "tenant_id": { "type": "keyword" },
-                "project_id": { "type": "keyword" }
+                "tenant_id": { 
+                    "type": "string", 
+                    "index": "not_analyzed" 
+                },
+                "project_id": { 
+                    "type": "string", 
+                    "index": "not_analyzed" 
+                }
             } 
         }
       }


### PR DESCRIPTION
First if all, thanks for the library, very useful and easy to setup.

We are working on a multitenant application and we are planning to use the `metadata` property to add the `tenant_id`.
When searching for matches we need to do it in the context of a specific tenant.

The idea of this PR is to add a new (optional) `filter` parameter to the `search_image` method, so that drivers could apply it before actually trying to find matches.

A few questions:

1. Does it make sense ? Are you interested in such a feature ?
2. ~~I'd like to write some tests for the ES implementation. Can anyone instruct me how do I run the integration tests ?~~
3. I have no idea how to add this feature to the Mongo driver. Is it a problem ?

