### PR TITLE
Handle unicode image paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 

--- a/image_match/goldberg.py
+++ b/image_match/goldberg.py
@@ -6,6 +6,7 @@ try:
     from cairosvg import svg2png
 except ImportError:
     pass
+from six import string_types, text_type
 from io import BytesIO
 import numpy as np
 import xml.etree
@@ -233,7 +234,8 @@ class ImageSignature(object):
                     raise CorruptImageError()
             img = img.convert('RGB')
             return rgb2gray(np.asarray(img, dtype=np.uint8))
-        elif type(image_or_path) is str:
+        elif type(image_or_path) in string_types or \
+             type(image_or_path) is text_type:
             return imread(image_or_path, as_grey=True)
         elif type(image_or_path) is bytes:
             try:

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ setup(
     install_requires=[
         'scikit-image>=0.12',
         'elasticsearch>=5.0.0,<6.0.0',
+        'six>=1.11.0',
     ],
     tests_require=tests_require,
     extras_require={

--- a/tests/test_elasticsearch_driver.py
+++ b/tests/test_elasticsearch_driver.py
@@ -1,7 +1,10 @@
 import pytest
-import urllib.request
 import os
 import hashlib
+try:
+    from urllib.request import urlretrieve
+except:
+    from urllib import urlretrieve
 from elasticsearch import Elasticsearch, ConnectionError, RequestError, NotFoundError
 from time import sleep
 
@@ -10,22 +13,22 @@ from PIL import Image
 
 test_img_url1 = 'https://camo.githubusercontent.com/810bdde0a88bc3f8ce70c5d85d8537c37f707abe/68747470733a2f2f75706c6f61642e77696b696d656469612e6f72672f77696b6970656469612f636f6d6d6f6e732f7468756d622f652f65632f4d6f6e615f4c6973612c5f62795f4c656f6e6172646f5f64615f56696e63692c5f66726f6d5f4332524d465f7265746f75636865642e6a70672f36383770782d4d6f6e615f4c6973612c5f62795f4c656f6e6172646f5f64615f56696e63692c5f66726f6d5f4332524d465f7265746f75636865642e6a7067'
 test_img_url2 = 'https://camo.githubusercontent.com/826e23bc3eca041110a5af467671b012606aa406/68747470733a2f2f63322e737461746963666c69636b722e636f6d2f382f373135382f363831343434343939315f303864383264653537655f7a2e6a7067'
-urllib.request.urlretrieve(test_img_url1, 'test1.jpg')
-urllib.request.urlretrieve(test_img_url2, 'test2.jpg')
+urlretrieve(test_img_url1, 'test1.jpg')
+urlretrieve(test_img_url2, 'test2.jpg')
 
 INDEX_NAME = 'test_environment_{}'.format(hashlib.md5(os.urandom(128)).hexdigest()[:12])
 DOC_TYPE = 'image'
 MAPPINGS = {
   "mappings": {
-    DOC_TYPE: { 
+    DOC_TYPE: {
       "dynamic": True,
-      "properties": { 
-        "metadata": { 
+      "properties": {
+        "metadata": {
             "type": "object",
             "dynamic": True,
-            "properties": { 
+            "properties": {
                 "tenant_id": { "type": "keyword" }
-            } 
+            }
         }
       }
     }
@@ -196,7 +199,7 @@ def test_lookup_with_filter_by_metadata(ses):
 
     r = ses.search_image('test1.jpg', pre_filter={"term": {"metadata.tenant_id": "bar-3"}})
     assert len(r) == 0
-    
+
 
 def test_all_orientations(ses):
     im = Image.open('test1.jpg')

--- a/tests/test_elasticsearch_driver_metadata_as_nested.py
+++ b/tests/test_elasticsearch_driver_metadata_as_nested.py
@@ -1,7 +1,10 @@
 import pytest
-import urllib.request
 import os
 import hashlib
+try:
+    from urllib.request import urlretrieve
+except:
+    from urllib import urlretrieve
 from elasticsearch import Elasticsearch, ConnectionError, RequestError, NotFoundError
 from time import sleep
 
@@ -10,23 +13,23 @@ from PIL import Image
 
 test_img_url1 = 'https://camo.githubusercontent.com/810bdde0a88bc3f8ce70c5d85d8537c37f707abe/68747470733a2f2f75706c6f61642e77696b696d656469612e6f72672f77696b6970656469612f636f6d6d6f6e732f7468756d622f652f65632f4d6f6e615f4c6973612c5f62795f4c656f6e6172646f5f64615f56696e63692c5f66726f6d5f4332524d465f7265746f75636865642e6a70672f36383770782d4d6f6e615f4c6973612c5f62795f4c656f6e6172646f5f64615f56696e63692c5f66726f6d5f4332524d465f7265746f75636865642e6a7067'
 test_img_url2 = 'https://camo.githubusercontent.com/826e23bc3eca041110a5af467671b012606aa406/68747470733a2f2f63322e737461746963666c69636b722e636f6d2f382f373135382f363831343434343939315f303864383264653537655f7a2e6a7067'
-urllib.request.urlretrieve(test_img_url1, 'test1.jpg')
-urllib.request.urlretrieve(test_img_url2, 'test2.jpg')
+urlretrieve(test_img_url1, 'test1.jpg')
+urlretrieve(test_img_url2, 'test2.jpg')
 
 INDEX_NAME = 'test_environment_{}'.format(hashlib.md5(os.urandom(128)).hexdigest()[:12])
 DOC_TYPE = 'image'
 MAPPINGS = {
   "mappings": {
-    DOC_TYPE: { 
+    DOC_TYPE: {
       "dynamic": True,
-      "properties": { 
-        "metadata": { 
+      "properties": {
+        "metadata": {
             "type": "nested",
             "dynamic": True,
-            "properties": { 
+            "properties": {
                 "tenant_id": { "type": "keyword" },
                 "project_id": { "type": "keyword" }
-            } 
+            }
         }
       }
     }
@@ -101,23 +104,23 @@ def test_lookup_with_filter_by_metadata(ses):
     assert len(r) == 2
 
     r = ses.search_image('test1.jpg', pre_filter=_nested_filter('foo', 'project-z'))
-    assert len(r) == 0  
+    assert len(r) == 0
 
     r = ses.search_image('test1.jpg', pre_filter=_nested_filter('bar', 'project-x'))
     assert len(r) == 1
 
     r = ses.search_image('test1.jpg', pre_filter=_nested_filter('bar-2', 'project-x'))
     assert len(r) == 0
-    
+
     r = ses.search_image('test1.jpg', pre_filter=_nested_filter('bar', 'project-z'))
-    assert len(r) == 0    
-    
+    assert len(r) == 0
+
 def _metadata(tenant_id, project_id):
     return dict(
             tenant_id=tenant_id,
             project_id=project_id
     )
-    
+
 def _nested_filter(tenant_id, project_id):
     return {
         "nested" : {
@@ -129,6 +132,6 @@ def _nested_filter(tenant_id, project_id):
                         {"term": {"metadata.project_id": project_id}}
                     ]
                 }
-             }            
+             }
         }
     }

--- a/tests/test_goldberg.py
+++ b/tests/test_goldberg.py
@@ -60,4 +60,4 @@ def test_difference():
     sig1 = gis.generate_signature('test.jpg')
     sig2 = gis.generate_signature(test_diff_img_url)
     dist = gis.normalized_distance(sig1, sig2)
-    assert dist == 0.42672771706789686
+    assert dist == 0.42263283502672722

--- a/tests/test_goldberg.py
+++ b/tests/test_goldberg.py
@@ -1,12 +1,15 @@
 import pytest
 from numpy import ndarray, array_equal
-import urllib.request
+try:
+    from urllib.request import urlretrieve
+except:
+    from urllib import urlretrieve
 
 from image_match.goldberg import ImageSignature, CorruptImageError
 
 test_img_url = 'https://camo.githubusercontent.com/810bdde0a88bc3f8ce70c5d85d8537c37f707abe/68747470733a2f2f75706c6f61642e77696b696d656469612e6f72672f77696b6970656469612f636f6d6d6f6e732f7468756d622f652f65632f4d6f6e615f4c6973612c5f62795f4c656f6e6172646f5f64615f56696e63692c5f66726f6d5f4332524d465f7265746f75636865642e6a70672f36383770782d4d6f6e615f4c6973612c5f62795f4c656f6e6172646f5f64615f56696e63692c5f66726f6d5f4332524d465f7265746f75636865642e6a7067'
 test_diff_img_url = 'https://camo.githubusercontent.com/826e23bc3eca041110a5af467671b012606aa406/68747470733a2f2f63322e737461746963666c69636b722e636f6d2f382f373135382f363831343434343939315f303864383264653537655f7a2e6a7067'
-urllib.request.urlretrieve(test_img_url, 'test.jpg')
+urlretrieve(test_img_url, 'test.jpg')
 
 
 def test_load_from_url():

--- a/tests/test_goldberg.py
+++ b/tests/test_goldberg.py
@@ -26,6 +26,17 @@ def test_load_from_file():
     assert sig.shape == (648,)
 
 
+def test_load_from_unicode_path():
+    try:
+        path = u'test.jpg'
+    except NameError:
+        return
+    gis = ImageSignature()
+    sig = gis.generate_signature(path)
+    assert type(sig) is ndarray
+    assert sig.shape == (648,)
+
+
 def test_load_from_stream():
     gis = ImageSignature()
     with open('test.jpg', 'rb') as f:


### PR DESCRIPTION
Howdy @rhsimplex, I've been working with this awesome library on a compute cluster on which the default Python is 2.7, and in the  process I've discovered that the extant codebase doesn't properly handle unicode image paths. I added a quick fix for that problem, and also ironed out a few wrinkles in the test suite so it can be run from Python 2.7 or 3.x. I'm happy to follow up if you'd like me to change any of this!