### PR TITLE
Update scikit-image to >=0.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         'pytest-runner',
     ],
     install_requires=[
-        'scikit-image>=0.12',
+        'scikit-image>=0.14',
         'elasticsearch>=5.0.0,<6.0.0',
         'six>=1.11.0',
     ],


### PR DESCRIPTION
Version 0.12 does not compile under Python 3.7, and 0.14 does not match with >=0.12 (because of semver shenanigans, I guess). So I'm upgrading to 0.14 to work with latest Python version. Tested locally and works ok.