### PR TITLE
compare between very black image causes div 0

### DIFF
--- a/image_match/goldberg.py
+++ b/image_match/goldberg.py
@@ -605,4 +605,6 @@ class ImageSignature(object):
         norm_diff = np.linalg.norm(b - a)
         norm1 = np.linalg.norm(b)
         norm2 = np.linalg.norm(a)
+        if norm1 + norm1 == 0:
+            return 0.0
         return norm_diff / (norm1 + norm2)


### PR DESCRIPTION
for this type of error

~/python3.6/dist-packages/image_match/goldberg.py:606: RuntimeWarning: invalid value encountered in double_scalars
return norm_diff / (norm1 + norm2)