### PR TITLE
fix: in py3.7, as grey typo is not only a warning but error

### DIFF
--- a/image_match/goldberg.py
+++ b/image_match/goldberg.py
@@ -236,14 +236,14 @@ class ImageSignature(object):
             return rgb2gray(np.asarray(img, dtype=np.uint8))
         elif type(image_or_path) in string_types or \
              type(image_or_path) is text_type:
-            return imread(image_or_path, as_grey=True)
+            return imread(image_or_path, as_gray=True)
         elif type(image_or_path) is bytes:
             try:
                 img = Image.open(image_or_path)
                 arr = np.array(img.convert('RGB'))
             except IOError:
                 # try again due to PIL weirdness
-                return imread(image_or_path, as_grey=True)
+                return imread(image_or_path, as_gray=True)
             if handle_mpo:
                 # take the first images from the MPO
                 if arr.shape == (2,) and isinstance(arr[1].tolist(), MpoImageFile):


### PR DESCRIPTION
```
self = <imageio.plugins.pillow.JPEGFormat.Reader object at 0x123399550>, format = <Format JPEG-PIL - JPEG (ISO 10918)>
request = <imageio.core.request.Request object at 0x1233999d0>

    def __init__(self, format, request):
        self.__closed = False
        self._BaseReaderWriter_last_index = -1
        self._format = format
        self._request = request
        # Open the reader/writer
>       self._open(**self.request.kwargs.copy())
E       TypeError: _open() got an unexpected keyword argument 'as_grey'

/usr/local/lib/python3.7/site-packages/imageio/core/format.py:221: TypeError
```

`as_gray` would be a fatal error in python 3.7.