### PR TITLE
Imageio as gray

### DIFF
--- a/image_match/goldberg.py
+++ b/image_match/goldberg.py
@@ -236,7 +236,7 @@ class ImageSignature(object):
             return rgb2gray(np.asarray(img, dtype=np.uint8))
         elif type(image_or_path) in string_types or \
              type(image_or_path) is text_type:
-            return imread(image_or_path, as_grey=True)
+            return imread(image_or_path, as_gray=True)
         elif type(image_or_path) is bytes:
             try:
                 img = Image.open(image_or_path)

--- a/image_match/goldberg.py
+++ b/image_match/goldberg.py
@@ -243,7 +243,7 @@ class ImageSignature(object):
                 arr = np.array(img.convert('RGB'))
             except IOError:
                 # try again due to PIL weirdness
-                return imread(image_or_path, as_grey=True)
+                return imread(image_or_path, as_gray=True)
             if handle_mpo:
                 # take the first images from the MPO
                 if arr.shape == (2,) and isinstance(arr[1].tolist(), MpoImageFile):


### PR DESCRIPTION
Changes argument from `as_grey` to `as_gray`. It fixes `TypeError: _open() got an unexpected keyword argument 'as_grey' ` when use `image-match` with newest version of `imageio`