### PR TITLE
docs: fix simple typo, represntation -> representation

### DIFF
--- a/image_match/signature_database_base.py
+++ b/image_match/signature_database_base.py
@@ -436,7 +436,7 @@ def words_to_int(word_array):
     coding_vector = 3**np.arange(width)
 
     # The 'plus one' here makes all digits positive, so that the
-    # integer represntation is strictly non-negative and unique
+    # integer representation is strictly non-negative and unique
     return np.dot(word_array + 1, coding_vector)
 
 


### PR DESCRIPTION
There is a small typo in image_match/signature_database_base.py.

Should read `representation` rather than `represntation`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md